### PR TITLE
Added basic hint functionality

### DIFF
--- a/src/commands/hint.js
+++ b/src/commands/hint.js
@@ -1,5 +1,4 @@
 import { InteractionResponse, SlashCommandBuilder } from "discord.js";
-//import { getMeme } from "../helpers/meme.js"; // Not needed
 const hintHelper = require('../helpers/hintHelper.js');
 
 export default {
@@ -11,23 +10,18 @@ export default {
         .setName("song_name")
         .setDescription("Choose a song")
         .setRequired(true)
-        /*.addChoices(
-          { name: "Pop", value: "pop" },
-          { name: "Hip Hop", value: "hiphop" },
-          { name: "Rock", value: "rock" },
-          { name: "Country", value: "country" },
-          { name: "Classical", value: "classical" },
-          { name: "Random", value: "random"}
-        )*/
     ),
 
   async execute(interaction) {
-    //const meme = await getMeme();
-    //const hint = hintHelper.getHint("radioactive");
-    const hint = hintHelper.getHint(interaction.options.getString("song_name"));
+    // This is not the final implementation; in the future it will detect which song is currently being
+    // guessed and get details from iTunes
+    let input = interaction.options.getString("song_name");
+    const hint = hintHelper.getHint(input);
 
     await interaction.reply({
-      content: "Hint: " + hint,
+      content: "Here is your hint: " + hint,
     });
+
+    
   },
 };

--- a/src/helpers/hintHelper.js
+++ b/src/helpers/hintHelper.js
@@ -2,11 +2,18 @@
 const hints = new Map([
     ["never gonna give you up", "Rick Astley"],
     ["bohemian rhapsody", "queen"],
-    ["radioactive", "imagine dragons"]
+    ["radioactive", "imagine dragons"],
+    ["ground control to major tom", "david bowie"],
+    ["mr blue sky", "Jeff Lynn"],
+    ["rap god", "eminem"],
+    ["tonight we are young", "fun."]
 ]);
 
 function getHint(songName){
-    return hints.get(songName);
+    if(hints.has(songName)){
+        return hints.get(songName);
+    }
+    return "This song is not in the list!";
 }
 
 module.exports = {


### PR DESCRIPTION
Added a primitive version of the hint command to build off later in the project.

In Discord, you will be able to use the /hint command and provide the name of a song to get a hint about (this behavior is temporary). There is a small list of songs that will work, which you can see by going to src/helpers/hintHelper.js.