### PR TITLE
Store scores per user and restrict /score to current user

### DIFF
--- a/src/commands/score.js
+++ b/src/commands/score.js
@@ -1,37 +1,27 @@
-import { InteractionResponse, SlashCommandBuilder } from "discord.js";
-const scoreStore = require('../helpers/scoreStore.js');
+import { SlashCommandBuilder } from "discord.js";
+import { getUserPoints } from "../helpers/scoreStore.js";
 
 export default {
   data: new SlashCommandBuilder()
     .setName("score")
-    .setDescription("Shows a player's current game score")
-    .addStringOption(option =>
-      option
-        .setName("user_name")
-        .setDescription("Enter a username (optional)")
-        .setRequired(false)
-    ),
+    .setDescription("Shows your current score"),
 
   async execute(interaction) {
-    let username = interaction.options.getString("user_name");
-
-    // If no username argument provided, set it to command runner's username
-    if(username == null){
-      username = interaction.user.tag;
-    }
-    const score = scoreStore.getScore(username);
-
-    // If scoreStore returned -1 it means the user's score is not recorded
-    if(score == -1){
-      await interaction.reply({
-        content : username + " has never played before, so they have no score.",
+    if (!interaction.guild) {
+      return interaction.reply({
+        content: "This command can only be used in a server.",
+        ephemeral: true,
       });
-      return;
     }
 
-    // Tell the score of the user
+    const guildId = interaction.guild.id;
+    const userId = interaction.user.id;
+
+    const score = getUserPoints(guildId, userId);
+
     await interaction.reply({
-      content : username + `'s current score: **${score}**`,
+      content: `Your current score: ${score}`,
+      ephemeral: true,
     });
   },
 };


### PR DESCRIPTION
This update modifies the /score command to return only the requesting user's score.

Scores are now retrieved using guildId and userId via scoreStore, ensuring:
- Scores are stored per user
- Scores are separated per guild
- Users cannot view other users' scores

This fulfills the user story requiring per-user score visibility.