### PR TITLE
Add /activeplayers command to display ranked players (#104)

### DIFF
--- a/src/commands/activeplayers.js
+++ b/src/commands/activeplayers.js
@@ -1,0 +1,50 @@
+import { SlashCommandBuilder, EmbedBuilder } from "discord.js";
+import { getSession } from "../gameState.js";
+import { getGuildScoresSorted } from "../helpers/scoreStore.js";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("activeplayers")
+    .setDescription("Displays ranked players in the current trivia session."),
+
+  async execute(interaction) {
+    const guild = interaction.guild;
+
+    if (!guild) {
+      return interaction.reply({
+        content: "This command can only be used in a server.",
+        ephemeral: true,
+      });
+    }
+
+    const session = getSession(guild.id);
+
+    if (!session || !session.active) {
+      return interaction.reply({
+        content: "ℹ️ No active trivia session in this server.",
+        ephemeral: true,
+      });
+    }
+
+    const scores = getGuildScoresSorted(guild.id);
+
+    if (!scores.length) {
+      return interaction.reply({
+        content: "No players have scored points yet.",
+      });
+    }
+
+    const ranked = scores
+      .map(([userId, points], index) => {
+        return `${index + 1}. <@${userId}> — **${points}**`;
+      })
+      .join("\n");
+
+    const embed = new EmbedBuilder()
+      .setColor(0x5865f2)
+      .setTitle("🏆 Active Player Rankings")
+      .setDescription(ranked);
+
+    await interaction.reply({ embeds: [embed] });
+  },
+};


### PR DESCRIPTION
Implements Issue #104

Adds a new slash command `/activeplayers` that displays the ranked players during an active trivia session.

The command:
- Uses existing score tracking via getGuildScoresSorted.
- Displays players in ranked order with their current points.
- Works mid-game without modifying game state.
- Handles the case where no session is active.
- Handles the case where no players have scored yet.

This feature integrates with the existing session and scoring system and is read-only.